### PR TITLE
Add support for virtualenv development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
+.venv
 Makefile
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pytest_cache/*
 .pydevproject
 .settings
 .settings/*
+.venv

--- a/README.md
+++ b/README.md
@@ -67,17 +67,15 @@ List of new features added to the original project commits
 
 ## Requirements
 
-### Production
-
 - Python 3.5+ (type hints are compatible with 3.5 upwards)
 
 Other requirements are on the `requirements.txt` file. Install them with `pip` or similar.
 
-### Development
+## Docker Environment
 
-- Docker and Docker Compose
+- Requires Docker and Docker Compose
 
-## Running
+### Running
 
 - copy `config.py.sample` to `config.py` and fill in.
 
@@ -99,16 +97,45 @@ sudo dpkg-reconfigure locales
 ```
 
 
-## Testing
-- Install requirements from `requirements-dev.txt` file.
-
+### Testing
+- Run tests:
 ```bash
 make test
 ```
 
-- To extract code coverage:
+- Extract code coverage:
 ```bash
 make coverage
+```
+
+## Virtualenv Environment
+
+1. Create the virtual environment:
+```bash
+$ python3 -m venv .venv
+```
+
+2. Activate it:
+```bash
+$ source .venv/bin/activate
+```
+
+3. Install dependencies (in the virtual environment):
+```bash
+(.venv) $ pip install -r requirements.txt
+(.venv) $ pip install -r requirements-dev.txt
+```
+
+4. You are now ready to run the test, extract coverage or run a testing server:
+```bash
+(.venv) $ # Run tests
+(.venv) $ pytest
+
+(.venv) $ # Extract coverage into './cov_html' folder
+(.venv) $ pytest --cov-report html:cov_html  --cov=. --cov-config .coveragerc
+
+(.venv) $ # Run testing server
+(.venv) $ python app.py
 ```
 
 ## Miscellaneous

--- a/test/test_linters.py
+++ b/test/test_linters.py
@@ -2,7 +2,7 @@ import subprocess
 import sys
 
 
-SOURCE_FOLDER = "."
+SOURCE_PATHS = "*.py test"
 
 
 def test_flake8_compliance() -> None:
@@ -10,7 +10,7 @@ def test_flake8_compliance() -> None:
                                             shell=True,
                                             stderr=sys.stderr).decode("ascii").replace("\n", "")
 
-    result = subprocess.call("{} {}".format(flake8_binary, SOURCE_FOLDER),
+    result = subprocess.call("{} {}".format(flake8_binary, SOURCE_PATHS),
                              shell=True,
                              stdout=sys.stdout,
                              stderr=sys.stderr)
@@ -24,7 +24,7 @@ def test_mypy_compliance() -> None:
 
     result = subprocess.call("{} --ignore-missing-imports --disallow-untyped-defs --check-untyped-defs"
                              " --warn-redundant-casts --warn-return-any --warn-unused-ignores --strict-optional"
-                             " {}".format(mypy_binary, SOURCE_FOLDER),
+                             " {}".format(mypy_binary, SOURCE_PATHS),
                              shell=True,
                              stdout=sys.stdout,
                              stderr=sys.stderr)


### PR DESCRIPTION
# Description

This change adds support for developing using `virtualenv` in Python 3.5+. Everything keeps working as usual with Docker.

This change supposes that the virtual environment is created in the folder `.venv` inside the `flask-calendar` repository. Other people might prefer a different folder name or even create it outside of the repository. Despite this, I think most changes here might prove useful, what do you think? :relaxed: 

# How was this tested?
- All `make` targets run OK.
- The `virtualenv` steps described in `README.md` were run OK.
