### PR TITLE
Simplify tests by using parametrize and subtests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ flake8
 mypy
 coverage
 pytest-cov
+pytest-subtests

--- a/test/test_app_utils.py
+++ b/test/test_app_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from app_utils import task_details_for_markup
 
 
@@ -5,68 +6,25 @@ SOURCE_STRING_PLACEHOLDER = "pre {} post"
 EXPECTED_STRING_PLACEHOLDER = "pre <a href=\"{}\" target=\"_blank\">{}</a> post"
 
 
-def test_http_standard_url_is_supported() -> None:
-    url = "http://test.test"
+@pytest.mark.parametrize("url, description", [
+    ("http://test.test", "standard http url"),
+    ("https://test.test", "standard https url"),
+    ("http://www.test.test", "www-prefixed url"),
+    ("http://127.0.0.1", "ip url"),
+    ("http://test.test/?test=test&test2=test2", "url with query string"),
+])
+def test_supported_task_details_for_markup(url: str, description: str) -> None:
     expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
     actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
     assert expected == actual
 
 
-def test_https_standard_url_is_supported() -> None:
-    url = "https://test.test"
+@pytest.mark.parametrize("url, description", [
+    ("http://test.test/#some=thing", "hash url"),
+    ("http://localhost/", "localhost url"),
+    ("http://test.test:8000", "specified port url"),
+])
+def test_unsupported_task_details_for_markup(url: str, description: str) -> None:
     expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
     actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected == actual
-
-
-def test_www_prefixed_url_is_supported() -> None:
-    url = "http://www.test.test"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected == actual
-
-
-def test_ip_url_is_supported() -> None:
-    url = "http://127.0.0.1"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected == actual
-
-
-def test_querystring_parameters_url_is_supported() -> None:
-    url = "http://test.test/?test=test&test2=test2"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected == actual
-
-
-# Unsupported urls
-
-
-def test_hash_url_is_unsupported() -> None:
-    url = "http://test.test/#some=thing"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected != actual
-
-
-def test_localhost_url_is_unsupported() -> None:
-    url = "http://localhost/"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
-    assert expected != actual
-
-
-def test_specified_port_url_is_unsupported() -> None:
-    url = "http://test.test:8000"
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-
     assert expected != actual

--- a/test/test_authentication.py
+++ b/test/test_authentication.py
@@ -12,16 +12,13 @@ def authentication() -> Authentication:
             data_folder="test/fixtures", password_salt="a test salt", failed_login_delay_base=0)
 
 
-def test_not_authenticated_if_username_doesnt_exists(authentication: Authentication) -> None:
-    assert authentication.is_valid(username="an_irrelevant_username", password="an_irrelevant_password") is False
-
-
-def test_not_authenticated_if_password_doesnt_matches(authentication: Authentication) -> None:
-    assert authentication.is_valid(username=EXISTING_USERNAME, password="an_irrelevant_password") is False
-
-
-def test_authenticated_if_credentials_correct(authentication: Authentication) -> None:
-    assert authentication.is_valid(username=EXISTING_USERNAME, password=CORRECT_PASSWORD) is True
+@pytest.mark.parametrize("username, password, expected", [
+    ("an_irrelevant_username", "an_irrelevant_password", False),
+    (EXISTING_USERNAME, "an_irrelevant_password", False),
+    (EXISTING_USERNAME, CORRECT_PASSWORD, True),
+])
+def test_is_valid_authentication(authentication: Authentication, username: str, password: str, expected: bool):
+    assert authentication.is_valid(username=username, password=password) is expected
 
 
 def test_retrieve_user_data(authentication: Authentication) -> None:

--- a/test/test_calendar_data.py
+++ b/test/test_calendar_data.py
@@ -10,31 +10,25 @@ def calendar_data() -> CalendarData:
     return CalendarData("test/fixtures")
 
 
-def test_no_data_nor_calendar_id_supplied_to_retrieve_tasks(calendar_data: CalendarData) -> None:
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, data=None, calendar_id=None)
-
-
-def test_errors_if_data_missing_keys(calendar_data: CalendarData) -> None:
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, calendar_id=None, data={})
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, calendar_id=None, data={"tasks": {}})
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, calendar_id=None, data={"tasks": {
+def test_error_retrieving_tasks_from_calendar(subtests, calendar_data: CalendarData) -> None:
+    test_data = [
+        {"year": 2001, "month": 1, "calendar_id": None, "data": None},
+        {"year": 2001, "month": 1, "calendar_id": None, "data": {}},
+        {"year": 2001, "month": 1, "calendar_id": None, "data": {"tasks": {}}},
+        {"year": 2001, "month": 1, "calendar_id": None, "data": {"tasks": {
             "normal": {},
-            "hidden_repetition": {}
-        }})
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, calendar_id=None, data={"tasks": {
+            "hidden_repetition": {}}}},
+        {"year": 2001, "month": 1, "calendar_id": None, "data": {"tasks": {
             "normal": {},
-            "repetition": {}
-        }})
-    with pytest.raises(ValueError):
-        calendar_data.tasks_from_calendar(year=2001, month=1, calendar_id=None, data={"tasks": {
+            "repetition": {}}}},
+        {"year": 2001, "month": 1, "calendar_id": None, "data": {"tasks": {
             "repetition": {},
-            "hidden_repetition": {}
-        }})
+            "hidden_repetition": {}}}},
+    ]
+    for data in test_data:
+        with subtests.test(data=data["data"]):
+            with pytest.raises(ValueError):
+                calendar_data.tasks_from_calendar(**data)
 
 
 def test_loads_a_valid_data_file(calendar_data: CalendarData) -> None:


### PR DESCRIPTION
## Description
Simplify some tests by using `parametrize` and `subtests` techniques. The latter requires to install a new pytest plugin: `pytest-subtests` ([ref]).

The changes proposed here have been the result of a first approach to `flask-calendar` by studying the available tests. They don't solve any problem nor add any feature, so feel free to discard them at will.

## How was this tested?
* Tests were forced to fail by changing the tested source code, in order to verify that they were still catching the same errors.


[ref]: https://pypi.org/project/pytest-subtests/