### PR TITLE
Show a warning message on setlocale exception

### DIFF
--- a/flask_calendar/app.py
+++ b/flask_calendar/app.py
@@ -22,8 +22,12 @@ authentication = Authentication(
     data_folder=config.USERS_DATA_FOLDER, password_salt=config.PASSWORD_SALT,
     failed_login_delay_base=config.FAILED_LOGIN_DELAY_BASE
 )
+
 if config.LOCALE is not None:
-    locale.setlocale(locale.LC_ALL, config.LOCALE)
+    try:
+        locale.setlocale(locale.LC_ALL, config.LOCALE)
+    except locale.Error as e:
+        app.logger.warning("{} ({})".format(str(e), config.LOCALE))
 
 
 # To avoid main_calendar_action below shallowing favicon requests and generating error logs


### PR DESCRIPTION
This PR allows program execution to continue in case the locale is not available. Without it, an exception was raised and execution aborted.

In case you consider that program execution should stop, we could log an error and exit in a controlled way.
