### PR TITLE
Add client/app fixtures and tests for login view

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,17 @@
 import pytest
 from flask import Flask
+from flask.testing import FlaskClient
 from flask_calendar.app import create_app
 
 
 @pytest.fixture
 def app() -> Flask:
-    return create_app()
+    return create_app({
+        'TESTING': True,
+        'FAILED_LOGIN_DELAY_BASE': 0,
+    })
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,0 +1,51 @@
+import pytest
+
+from flask.testing import FlaskClient
+
+from flask_calendar.constants import SESSION_ID
+
+
+@pytest.mark.parametrize(('username', 'password', 'success'), (
+    ('', '', False),
+    ('wrong_username', '', False),
+    ('a_username', '', False),
+    ('a_username', 'wrong_password', False),
+    ('a_username', 'a_password', True)
+))
+def test_login_credentials(client: FlaskClient, username: str, password: str, success: bool) -> None:
+    response = client.post('/do_login', data=dict(
+        username=username,
+        password=password
+    ))
+    assert response.status_code == 302
+    if success:
+        assert response.headers['Location'] == 'http://localhost/'
+    else:
+        assert response.headers['Location'] == 'http://localhost/login'
+
+
+@pytest.mark.parametrize(('username', 'password', 'success'), (
+    ('', '', False),
+    ('wrong_username', '', False),
+    ('a_username', '', False),
+    ('a_username', 'wrong_password', False),
+    ('a_username', 'a_password', True)
+))
+def test_session_id_cookie_set_when_logged_in(client: FlaskClient, username: str, password: str, success: bool) -> None:
+    response = client.post('/do_login', data=dict(
+        username=username,
+        password=password
+    ))
+    assert response.status_code == 302
+    cookie = next((c for c in client.cookie_jar), None)
+    if cookie is not None:
+        assert success and cookie.name == SESSION_ID
+    else:
+        assert not success and cookie is None
+
+
+def test_redirects_to_calendar_when_logged_in(client: FlaskClient) -> None:
+    client.post('/do_login', data=dict(username='a_username', password='a_password'))
+    response = client.get('/')
+    assert response.status_code == 302
+    assert response.headers['Location'] == 'http://localhost/sample/'


### PR DESCRIPTION
Adds:
- client and app pytest fixtures using the new `create_app()` factory method.
- Test login credentials in login view.
- Test that session cookie is set after correct login.
- Test that login redirects to default calendar if credentials were valid.