### PR TITLE
Create app factory to simplify config substitution in tests

### DIFF
--- a/flask_calendar/app.py
+++ b/flask_calendar/app.py
@@ -2,13 +2,11 @@
 
 import locale
 import os
-from typing import cast
+from typing import cast, Dict
 
 from flask import Flask, Response, send_from_directory
 
-import config
-from flask_calendar.authentication import Authentication
-
+import config  # noqa: F401
 
 from flask_calendar.actions import (index_action, login_action, do_login_action, main_calendar_action, new_task_action,
                                     edit_task_action, update_task_action, save_task_action, delete_task_action,
@@ -16,48 +14,48 @@ from flask_calendar.actions import (index_action, login_action, do_login_action,
 from flask_calendar.app_utils import task_details_for_markup
 
 
-app = Flask(__name__)
+def create_app(config_overrides: Dict = None) -> Flask:
+    app = Flask(__name__)
+    app.config.from_object('config')
 
-authentication = Authentication(
-    data_folder=config.USERS_DATA_FOLDER, password_salt=config.PASSWORD_SALT,
-    failed_login_delay_base=config.FAILED_LOGIN_DELAY_BASE
-)
+    if config_overrides is not None:
+        app.config.from_mapping(config_overrides)
 
-if config.LOCALE is not None:
-    try:
-        locale.setlocale(locale.LC_ALL, config.LOCALE)
-    except locale.Error as e:
-        app.logger.warning("{} ({})".format(str(e), config.LOCALE))
+    if app.config['LOCALE'] is not None:
+        try:
+            locale.setlocale(locale.LC_ALL, app.config['LOCALE'])
+        except locale.Error as e:
+            app.logger.warning("{} ({})".format(str(e), app.config['LOCALE']))
 
+    # To avoid main_calendar_action below shallowing favicon requests and generating error logs
+    @app.route('/favicon.ico')
+    def favicon() -> Response:
+        return cast(Response, send_from_directory(
+            os.path.join(cast(str, app.root_path), 'static'), 'favicon.ico', mimetype='image/vnd.microsoft.icon')
+        )
 
-# To avoid main_calendar_action below shallowing favicon requests and generating error logs
-@app.route('/favicon.ico')
-def favicon() -> Response:
-    return cast(Response, send_from_directory(
-        os.path.join(cast(str, app.root_path), 'static'), 'favicon.ico', mimetype='image/vnd.microsoft.icon')
-    )
+    app.add_url_rule("/", "index_action", index_action, methods=["GET"])
+    app.add_url_rule("/login", "login_action", login_action, methods=["GET"])
+    app.add_url_rule("/do_login", "do_login_action", do_login_action, methods=["POST"])
+    app.add_url_rule("/<calendar_id>/", "main_calendar_action", main_calendar_action, methods=["GET"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/new_task", "new_task_action", new_task_action, methods=["GET"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "edit_task_action", edit_task_action,
+                     methods=["GET"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/task/<task_id>", "update_task_action", update_task_action,
+                     methods=["POST"])
+    app.add_url_rule("/<calendar_id>/new_task", "save_task_action", save_task_action, methods=["POST"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "delete_task_action", delete_task_action,
+                     methods=["DELETE"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "update_task_day_action", update_task_day_action,
+                     methods=["PUT"])
+    app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/hide/", "hide_repetition_task_instance_action",
+                     hide_repetition_task_instance_action, methods=["POST"])
 
+    app.jinja_env.filters['task_details_for_markup'] = task_details_for_markup
 
-app.add_url_rule("/", "index_action", index_action, methods=["GET"])
-app.add_url_rule("/login", "login_action", login_action, methods=["GET"])
-app.add_url_rule("/do_login", "do_login_action", do_login_action, methods=["POST"])
-app.add_url_rule("/<calendar_id>/", "main_calendar_action", main_calendar_action, methods=["GET"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/new_task", "new_task_action", new_task_action, methods=["GET"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "edit_task_action", edit_task_action,
-                 methods=["GET"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/task/<task_id>", "update_task_action", update_task_action,
-                 methods=["POST"])
-app.add_url_rule("/<calendar_id>/new_task", "save_task_action", save_task_action, methods=["POST"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "delete_task_action", delete_task_action,
-                 methods=["DELETE"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/", "update_task_day_action", update_task_day_action,
-                 methods=["PUT"])
-app.add_url_rule("/<calendar_id>/<year>/<month>/<day>/<task_id>/hide/", "hide_repetition_task_instance_action",
-                 hide_repetition_task_instance_action, methods=["POST"])
-
-
-app.jinja_env.filters['task_details_for_markup'] = task_details_for_markup
+    return app
 
 
 if __name__ == "__main__":
-    app.run(debug=config.DEBUG, host=config.HOST_IP)
+    app = create_app()
+    app.run(debug=app.config['DEBUG'], host=app.config['HOST_IP'])

--- a/flask_calendar/app_utils.py
+++ b/flask_calendar/app_utils.py
@@ -4,9 +4,8 @@ from typing import Any, Callable
 import uuid
 from cachelib.simple import SimpleCache
 
-from flask import abort, redirect, request
+from flask import abort, redirect, request, current_app
 
-import config
 # from authentication import Authentication
 from flask_calendar.authorization import Authorization
 from flask_calendar.calendar_data import CalendarData
@@ -36,7 +35,7 @@ def authorized(decorated_function: Callable) -> Any:
     @wraps(decorated_function)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         username = get_session_username(str(request.cookies.get(SESSION_ID)))
-        authorization = Authorization(calendar_data=CalendarData(data_folder=config.DATA_FOLDER))
+        authorization = Authorization(calendar_data=CalendarData(data_folder=current_app.config['DATA_FOLDER']))
         if "calendar_id" not in kwargs:
             raise ValueError("calendar_id")
         calendar_id = str(kwargs["calendar_id"])
@@ -48,12 +47,20 @@ def authorized(decorated_function: Callable) -> Any:
 
 def previous_month_link(year: int, month: int) -> str:
     month, year = GregorianCalendar.previous_month_and_year(year=year, month=month)
-    return "" if year < config.MIN_YEAR or year > config.MAX_YEAR else "?y={}&m={}".format(year, month)
+    return (
+        ""
+        if year < current_app.config['MIN_YEAR'] or year > current_app.config['MAX_YEAR']
+        else "?y={}&m={}".format(year, month)
+    )
 
 
 def next_month_link(year: int, month: int) -> str:
     month, year = GregorianCalendar.next_month_and_year(year=year, month=month)
-    return "" if year < config.MIN_YEAR or year > config.MAX_YEAR else "?y={}&m={}".format(year, month)
+    return (
+        ""
+        if year < current_app.config['MIN_YEAR'] or year > current_app.config['MAX_YEAR']
+        else "?y={}&m={}".format(year, month)
+    )
 
 
 def new_session_id() -> str:
@@ -73,7 +80,7 @@ def get_session_username(session_id: str) -> str:
 
 
 def task_details_for_markup(details: str) -> str:
-    if not config.AUTO_DECORATE_TASK_DETAILS_HYPERLINK:
+    if not current_app.config['AUTO_DECORATE_TASK_DETAILS_HYPERLINK']:
         return details
 
     decorated_fragments = []

--- a/flask_calendar/calendar_data.py
+++ b/flask_calendar/calendar_data.py
@@ -4,7 +4,8 @@ import os
 import time
 from typing import (cast, Dict, List, Optional)
 
-import config
+from flask import current_app
+
 from flask_calendar.gregorian_calendar import GregorianCalendar
 
 
@@ -343,7 +344,7 @@ class CalendarData:
             for year in data[KEY_TASKS][KEY_REPETITIVE_HIDDEN_TASK][task_id]:
                 for month in data[KEY_TASKS][KEY_REPETITIVE_HIDDEN_TASK][task_id][year]:
                     task_date = datetime(int(year), int(month), 1, 0, 0)
-                    if (current_date - task_date).days > config.DAYS_PAST_TO_KEEP_HIDDEN_TASKS:
+                    if (current_date - task_date).days > current_app.config['DAYS_PAST_TO_KEEP_HIDDEN_TASKS']:
                         tasks_to_delete.append((year, month, task_id))
 
         for task_info in tasks_to_delete:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from flask import Flask
+from flask_calendar.app import create_app
+
+
+@pytest.fixture
+def app() -> Flask:
+    return create_app()

--- a/test/test_app_utils.py
+++ b/test/test_app_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import Flask
 from flask_calendar.app_utils import task_details_for_markup
 
 
@@ -13,10 +14,11 @@ EXPECTED_STRING_PLACEHOLDER = "pre <a href=\"{}\" target=\"_blank\">{}</a> post"
     ("http://127.0.0.1", "ip url"),
     ("http://test.test/?test=test&test2=test2", "url with query string"),
 ])
-def test_supported_task_details_for_markup(url: str, description: str) -> None:
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-    assert expected == actual
+def test_supported_task_details_for_markup(app: Flask, url: str, description: str) -> None:
+    with app.app_context():
+        expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
+        actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
+        assert expected == actual
 
 
 @pytest.mark.parametrize("url, description", [
@@ -24,7 +26,8 @@ def test_supported_task_details_for_markup(url: str, description: str) -> None:
     ("http://localhost/", "localhost url"),
     ("http://test.test:8000", "specified port url"),
 ])
-def test_unsupported_task_details_for_markup(url: str, description: str) -> None:
-    expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
-    actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
-    assert expected != actual
+def test_unsupported_task_details_for_markup(app: Flask, url: str, description: str) -> None:
+    with app.app_context():
+        expected = EXPECTED_STRING_PLACEHOLDER.format(url, url)
+        actual = task_details_for_markup(SOURCE_STRING_PLACEHOLDER.format(url))
+        assert expected != actual


### PR DESCRIPTION
This should make it easier to change configuration options in tests. Besides that, we have more control over how and when the `app` object is created.