### PR TITLE
chore: update precommit hooks + enable renovatebot for it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
 
@@ -11,12 +11,12 @@ repos:
     hooks:
     -   id: flake8
 
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.7.0
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
     hooks:
     -   id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.10.0
     hooks:
     - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
-target-version = ['py35']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "assigneesFromCodeOwners": true,
   "packageRules": [
     {


### PR DESCRIPTION
- Bump `trailing-whitespace` hook to 4.x
- Update `isort` and now using new source (original was archived)
- Update `black` + cover recent Python 3 versions range ([info](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version))
- Enable pre-commit RenovateBot updates ([info](https://docs.renovatebot.com/modules/manager/pre-commit/))